### PR TITLE
Load Vanilla Python skill

### DIFF
--- a/samples/dotnet/PythonSkillRunner/Program.cs
+++ b/samples/dotnet/PythonSkillRunner/Program.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-
-using DotnetReferenceSkill;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.KernelExtensions;
 using Microsoft.SemanticKernel.Orchestration;
+using Python.Runtime;
+using PythonSkillRunner;
 
 const string RANDOM_ACTIVITY_PROMPT = "Find me an activity to do, return only a single activity. I like to {{$INPUT}}. Be creative!";
 const string DEGREES_OF_SEPARATION_PROMPT = "How many degrees of separation are there between {{$ITEM1}} and {{$ITEM2}}? Bonus points for Kevin Bacon reference.";
@@ -12,7 +12,6 @@ const string DEGREES_OF_SEPARATION_PROMPT = "How many degrees of separation are 
 var key = "";
 var endpoint = "";
 var model = "";
-
 
 var sk = Kernel.Builder.Configure(c => c.AddAzureOpenAICompletionBackend(model, model, endpoint, key)).Build();
 
@@ -33,16 +32,13 @@ sk.CreateSemanticFunction(DEGREES_OF_SEPARATION_PROMPT,
             temperature: 0.2,
             topP: 0.5);
 #endregion
-
-//TODO: load your python skill here
-//currently loading a skill that will pull a random activity from an API.
-//We will compare the activity to the one from the LLM and return true if they match, false if not
-var randomActivitySkill = new RandomActivitySkill();
-sk.ImportSkill(randomActivitySkill, nameof(RandomActivitySkill));
-
-var thingiliketodo = "surf";
+var thingiliketodo = "read";
 var llmResult = string.Empty;
 var apiResult = string.Empty;
+
+//We will compare the activity to the one from the LLM and return true if they match, false if not
+var randomActivitySkill = new PythonRandomActivitySkill();
+sk.ImportSkill(randomActivitySkill, nameof(PythonRandomActivitySkill));
 
 //ask the LLM for a random activity
 var llmRandomActivityResult = await sk.RunAsync(thingiliketodo, sk.Skills.GetSemanticFunction("RandomActivityLLMSkill", "GetRandomActivity"));
@@ -50,7 +46,7 @@ llmResult = llmRandomActivityResult.Result;
 Console.WriteLine("LLM suggested: " + llmResult);
 
 //ask the skill to find us a random activity via API
-var skillApiRandomActivityResult = await sk.RunAsync(sk.Skills.GetNativeFunction(nameof(RandomActivitySkill), "GetRandomActivity"));
+var skillApiRandomActivityResult = await sk.RunAsync(sk.Skills.GetNativeFunction(nameof(PythonRandomActivitySkill), "GetRandomActivity"));
 apiResult = skillApiRandomActivityResult.Result;
 Console.WriteLine("Skill suggested: " + apiResult);
 

--- a/samples/dotnet/PythonSkillRunner/PythonSkillRunner.csproj
+++ b/samples/dotnet/PythonSkillRunner/PythonSkillRunner.csproj
@@ -1,15 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="QuantConnect.pythonnet" Version="2.0.18" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\dotnet\src\SemanticKernel\SemanticKernel.csproj" />
-    <ProjectReference Include="..\DotnetReferenceSkill\DotnetReferenceSkill.csproj" />
+    <ProjectReference Include="..\kernel-syntax-examples\KernelSyntaxExamples.csproj" />
+    <ProjectReference Include="..\KernelBuilder\KernelBuilder.csproj" />
+    <ProjectReference Include="..\KernelHttpServer\KernelHttpServer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/dotnet/PythonSkillRunner/RandomActivitySkill.cs
+++ b/samples/dotnet/PythonSkillRunner/RandomActivitySkill.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.SkillDefinition;
+using Python.Runtime;
+
+namespace PythonSkillRunner;
+internal class PythonRandomActivitySkill
+{
+
+        [SKFunction("Gets a random activity from an API")]
+        [SKFunctionName("GetRandomActivity")]
+        public string GetRandomActivityAsync()
+        {
+            PythonEngine.Initialize();
+            using (Py.GIL())
+            {
+                dynamic sys = Py.Import("sys");
+                // Env variable PYTHONPATH contains the directory for the pythonskills module
+                var pythonpath = Environment.GetEnvironmentVariable("PYTHONPATH");
+                sys.path.insert(0, pythonpath);
+                dynamic skill = Py.Import("pythonskills.randomActivitySkill");
+                return (string) skill.RandomActivitySkill.getRandomActivity();
+            }
+        }
+}

--- a/samples/dotnet/PythonSkillRunner/RandomActivitySkillTest.cs
+++ b/samples/dotnet/PythonSkillRunner/RandomActivitySkillTest.cs
@@ -1,0 +1,17 @@
+﻿namespace PythonSkillRunner;
+
+public class RandomActivitySkillTest
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void GetRandomActivityAsync_ShouldReturnActivity()
+    {
+        var skill = new PythonRandomActivitySkill();
+        var output = skill.GetRandomActivityAsync();
+        Assert.IsTrue(output.Length > 0, "The output should not be empty.");
+    }
+}

--- a/samples/dotnet/PythonSkillRunner/Usings.cs
+++ b/samples/dotnet/PythonSkillRunner/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/samples/dotnet/PythonSkillRunner/pythonskills/randomActivitySkill.py
+++ b/samples/dotnet/PythonSkillRunner/pythonskills/randomActivitySkill.py
@@ -1,0 +1,8 @@
+import requests
+import json
+class RandomActivitySkill:
+
+    def getRandomActivity():
+        result = requests.get('https://www.boredapi.com/api/activity').text;
+        activityObject = json.loads(result);
+        return activityObject['activity']


### PR DESCRIPTION
### Motivation and Context

This pull request addresses the need expressed by several teams within the company to have "the kernel" available in their preferred language. Accommodating this request is important because it allows teams to work more effectively and efficiently in their native language. As described in the original statement, some teams may be hesitant to work with the kernel in a language they do not have experience supporting, and our current offerings do not include a hosted service for them to consume. Additionally, allowing teams to build native skills in their language of choice will ultimately lead to a stronger and more versatile product. 



### Description
This pull request introduces functionality that allows Python to be bridged into .NET using [Python.Net](https://pythonnet.github.io/pythonnet/dotnet.html). Python.Net promise nearly seamless integration between Python and .NET 4.-+.

Specifically, the code creates a simple Python script and calls it within .NET, and includes a wrapper class in .NET that can be used to call Python modules. 

### Considerations
1. Python.Net throws error for Python v3.9+
    - https://github.com/pythonnet/pythonnet/issues/2066
2. Python.Net can also embed .NET code into Python which could potentially allow using SemanticKernel inside python script
    - https://pythonnet.github.io/pythonnet/python.html
     
  ### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
